### PR TITLE
UI Enhancement: Keep results visible when switching tools

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -1,5 +1,6 @@
 // State management
 let currentTool = 'cms-detect';
+let lastScannedTool = null;
 
 // Import technology patterns
 import { TECH_PATTERNS } from './tech-patterns.js';
@@ -55,7 +56,10 @@ form.addEventListener('submit', async (e) => {
         const url = new URL(targetUrl);
         
         hideError();
-        hideResults(); // Only hide results when starting a new scan
+        // Only hide results if scanning with the same tool
+        if (currentTool === lastScannedTool) {
+            hideResults();
+        }
         showLoading();
 
         let results;
@@ -88,6 +92,7 @@ form.addEventListener('submit', async (e) => {
                 throw new Error('Tool not implemented');
         }
         showResults(results);
+        lastScannedTool = currentTool;
     } catch (error) {
         if (error instanceof TypeError && error.message.includes('URL')) {
             showError('Please enter a valid URL (e.g., https://example.com)');


### PR DESCRIPTION
## Changes
- Added `lastScannedTool` state variable to track the last tool used for scanning
- Modified results visibility logic to persist results when switching between tools
- Updated form submission handler to only hide results when running the same tool again
- Results now remain visible until a new scan is completed with the same tool

## Testing
The changes can be verified by:
1. Running a scan with one tool
2. Switching to a different tool (results should stay visible)
3. Running another scan with the same tool (previous results should hide)
4. Running a scan with a different tool (previous results should stay visible until new results appear)

## Preview
Once the PR is created, a preview deployment will be automatically generated to test these changes in a live environment.